### PR TITLE
Using the chain nonce, ignoring the transaction queue nonce for Parts…

### DIFF
--- a/crates/ethcore/src/engines/hbbft/contracts/keygen_history.rs
+++ b/crates/ethcore/src/engines/hbbft/contracts/keygen_history.rs
@@ -301,7 +301,7 @@ pub fn send_keygen_transactions(
 
         let part_transaction = TransactionRequest::call(*KEYGEN_HISTORY_ADDRESS, write_part_data.0)
             .gas(U256::from(gas))
-            .nonce(full_client.next_nonce(&address))
+            .nonce(full_client.nonce(&address, BlockId::Latest).unwrap())
             .gas_price(U256::from(10000000000u64));
         full_client
             .transact_silently(part_transaction)
@@ -347,7 +347,7 @@ pub fn send_keygen_transactions(
 
         let acks_transaction = TransactionRequest::call(*KEYGEN_HISTORY_ADDRESS, write_acks_data.0)
             .gas(U256::from(gas))
-            .nonce(full_client.next_nonce(&address))
+            .nonce(full_client.nonce(&address, BlockId::Latest).unwrap())
             .gas_price(U256::from(10000000000u64));
         full_client
             .transact_silently(acks_transaction)


### PR DESCRIPTION
…/Acks transactions.

It is *not* guaranteed that nodes receiving the transactions are on the same block height as the sender. This can lead to transactions getting rejected by the transaction permission contract. Such transactions get removed on the receiving node, causing a Nonce gap preventing following re-tries to fail since they are sent with a larger nonce.