### PR TITLE
Implemented maximum block time for hbbft engine.

### DIFF
--- a/crates/ethcore/res/chainspec/honey_badger_bft.json
+++ b/crates/ethcore/res/chainspec/honey_badger_bft.json
@@ -4,6 +4,7 @@
 		"hbbft": {
 			"params": {
 				"minimumBlockTime": 0,
+				"maximumBlockTime": 600,
 				"transactionQueueSizeTrigger": 1,
 				"isUnitTest": true,
 				"blockRewardContractAddress": "0x2000000000000000000000000000000000000001"

--- a/crates/ethjson/src/spec/hbbft.rs
+++ b/crates/ethjson/src/spec/hbbft.rs
@@ -26,6 +26,8 @@ use serde::Deserialize;
 pub struct HbbftParams {
     /// The minimum time duration between blocks, in seconds.
     pub minimum_block_time: u64,
+    /// The maximum time duration between blocks, in seconds.
+    pub maximum_block_time: u64,
     /// The length of the transaction queue at which block creation should be triggered.
     pub transaction_queue_size_trigger: usize,
     /// Should be true when running unit tests to avoid starting timers.
@@ -45,25 +47,29 @@ pub struct Hbbft {
 #[cfg(test)]
 mod tests {
     use super::Hbbft;
+    use ethereum_types::Address;
+    use std::str::FromStr;
 
     #[test]
     fn hbbft_deserialization() {
         let s = r#"{
 			"params": {
 				"minimumBlockTime": 0,
+				"maximumBlockTime": 600,
 				"transactionQueueSizeTrigger": 1,
 				"isUnitTest": true,
-				"blockRewardContractAddress": "0x2000000000000000000000000000000000000002",
+				"blockRewardContractAddress": "0x2000000000000000000000000000000000000002"
 			}
 		}"#;
 
         let deserialized: Hbbft = serde_json::from_str(s).unwrap();
         assert_eq!(deserialized.params.minimum_block_time, 0);
+        assert_eq!(deserialized.params.maximum_block_time, 600);
         assert_eq!(deserialized.params.transaction_queue_size_trigger, 1);
         assert_eq!(deserialized.params.is_unit_test, Some(true));
         assert_eq!(
             deserialized.params.block_reward_contract_address,
-            Address::from("0x2000000000000000000000000000000000000002")
+            Address::from_str("2000000000000000000000000000000000000002").ok()
         );
     }
 }


### PR DESCRIPTION
integrates maximum block time for hbbft engine ( aka "Heartbeat": https://github.com/DMDcoin/openethereum-3.x/issues/8 )

Note: requires a new configuration setting hbbft param: `maximumBlockTime`.
It tells the length of a heartbeat. 